### PR TITLE
Add test for symbol-new --help

### DIFF
--- a/symbol-new
+++ b/symbol-new
@@ -153,6 +153,10 @@ while [[ $# -gt 0 ]]; do
       echo "$VERSION"
       exit
       ;;
+    -h|--help)
+      print_help
+      exit
+      ;;
     -*)
       error "Unrecognized option: $1"
       print_help

--- a/tests/symbol-new-help.sh
+++ b/tests/symbol-new-help.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source tests/logging.sh
+
+make install prefix=. &> /dev/null
+
+# TODO(jez) This would probably be better suited as a snapshot test.
+# If you add snapshot tests, also add a way to automatically update them.
+
+check_help() {
+  grep -q 'symbol-new: '
+}
+
+if ! { bin/symbol-new -h | check_help ; }; then
+  error "Did not see symbol-new help output with -h"
+  exit 1
+fi
+
+if ! { bin/symbol-new --help | check_help ; }; then
+  error "Did not see symbol-new help output with --help"
+  exit 1
+fi


### PR DESCRIPTION
This is the first in a series of PR's to add more tests.

Part of this change is to make the testing framework a little nicer (cleaning
up using `git clean` between tests so that fewer things can carry over between
tests.)